### PR TITLE
Introduce unified game object registry

### DIFF
--- a/GameModel.Tests/GameSessionTests.cs
+++ b/GameModel.Tests/GameSessionTests.cs
@@ -1,0 +1,24 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using GameModel;
+using GameModel.Actions;
+using GameModel.Model;
+
+namespace GameEngine.Tests;
+
+[TestClass]
+public class GameSessionTests
+{
+    [TestMethod]
+    public void GetGameElement_TypedAndGeneric_ReturnsObjects()
+    {
+        var session = GameSession.NewGame("../packs/clue.json");
+
+        var scene = session.GetGameElement<Scene>("hall");
+        Assert.IsNotNull(scene);
+        Assert.AreEqual("hall", scene!.Id);
+
+        var generic = session.GetGameElement("candlestick");
+        Assert.IsNotNull(generic);
+        Assert.AreEqual("candlestick", generic!.Id);
+    }
+}

--- a/GameModel/GameElementInfo.cs
+++ b/GameModel/GameElementInfo.cs
@@ -1,0 +1,14 @@
+using GameModel.Model;
+
+namespace GameModel;
+
+public class GameElementInfo
+{
+    public required string Type { get; init; }
+    public required IGameElement Element { get; init; }
+    public string State { get; set; } = "default";
+    public string? LocationId { get; set; }
+    public List<string> Exits { get; set; } = [];
+
+    public T? Get<T>() where T : class, IGameElement => Element as T;
+}


### PR DESCRIPTION
## Summary
- add `GameElementInfo` to track runtime state, location and exits
- consolidate lookup dictionaries in `GameSession` into a single `Elements` dictionary
- update action handlers to use new registry and maintain locations
- provide typed and generic `GetGameElement` helpers
- add tests for retrieving objects

## Testing
- `dotnet test --no-build GameModel.Tests/GameModel.Tests.csproj` *(fails: `dotnet` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687d5b0191c88328845e3b797d207b95