### PR TITLE
Move scene look logic into Scene.ToDescription

### DIFF
--- a/GameModel/Actions/ActionHandlers.cs
+++ b/GameModel/Actions/ActionHandlers.cs
@@ -26,7 +26,7 @@ public static class ActionHandlers
         }
         else
         {
-            return LookScene(session, action, session.CurrentScene);
+            return session.CurrentScene.ToDescription(session);
         }
 
     }
@@ -62,78 +62,10 @@ public static class ActionHandlers
         session.CurrentScene = session.GetGameElement<Scene>(exitId.TargetId)!;
         session.Elements["player:player"].LocationId = session.CurrentScene.Id; 
 
-        return LookScene(session, action, session.CurrentScene);
+        return session.CurrentScene.ToDescription(session);
     }
 
 
-
-    private static string LookScene(GameSession session, PlayerAction action, Scene scene)
-    {
-        StringBuilder sb = new();
-        int i = 1;
-        //I am looking at the scene
-        sb.AppendLine(scene.Description);
-        var whoishere = session.Elements.GetInLocation(scene.Id);
-
-        var npcs = whoishere.Where(x => x.Id.StartsWith("npc:"));
-        if (npcs.Any())
-        {
-            sb.AppendLine("");
-            sb.AppendLine("The following people are here:");
-            i = 0;
-            foreach (var item in npcs)
-            {
-                var npc = session.GetGameElement<Npc>(item.Id);
-                if (npc != null)
-                    sb.AppendLine($"{++i}. {npc.Name} ({npc.Id})");
-            }
-        }
-        else
-        {
-            sb.AppendLine("");
-            sb.AppendLine("No one is here.");
-        }
-
-        var items = whoishere.Where(x => x.Id.StartsWith("item:"));
-        if (items.Any())
-        {
-            sb.AppendLine("");
-            sb.AppendLine("You see the following items:");
-            i = 0;
-            foreach (var item in items)
-            {
-                var itm = session.GetGameElement<Item>(item.Id);
-                if (itm != null)
-                    sb.AppendLine($"{++i}. {itm.Name}");
-            }
-        }
-        else
-        {
-            sb.AppendLine("");
-            sb.AppendLine("There are no items here.");
-        }
-
-
-        if (scene.Exits.ToList().Any())
-        {
-            sb.AppendLine("");
-            sb.AppendLine("You can see these exits:");
-            i = 0;
-            foreach (var exit in scene.Exits)
-            {
-                var exScene = session.GetGameElement<Scene>(exit.TargetId);
-                var name = exScene?.Name ?? exit.Name;
-                sb.AppendLine($"{++i}. {exit.Name} ({exit.TargetId})");
-            }
-        }
-        else
-        {
-            sb.AppendLine("");
-            sb.AppendLine("There are no exits from here.");
-        }
-
-        return sb.ToString();
-    }
 
     public static string HandleInventoryGet(GameSession session, PlayerAction action)
     {

--- a/GameModel/Model/Scene.cs
+++ b/GameModel/Model/Scene.cs
@@ -1,8 +1,88 @@
+using System;
+using System.Text;
+using System.Linq;
+using GameModel;
+
 namespace GameModel.Model;
 
 public class Scene : GameElement
 {
     public List<Exit> Exits { get; set; } = [];
-    
 
+    /// <summary>
+    /// Returns the full description of the scene including NPCs, items and exits.
+    /// </summary>
+    public string ToDescription(GameSession session)
+    {
+        var stateId = session.Elements.TryGetValue(Id, out var info)
+            ? info.State
+            : DefaultState;
+
+        StringBuilder sb = new();
+        sb.AppendLine(base.ToDescription(stateId).Trim());
+
+        var whoIsHere = session.Elements.GetInLocation(Id);
+
+        var npcs = whoIsHere.Where(x => x.Id.StartsWith("npc:"));
+        if (npcs.Any())
+        {
+            sb.AppendLine();
+            sb.AppendLine("The following people are here:");
+            int i = 0;
+            foreach (var npcInfo in npcs)
+            {
+                var npc = session.GetGameElement<Npc>(npcInfo.Id);
+                if (npc != null)
+                    sb.AppendLine($"{++i}. {npc.Name} ({npc.Id})");
+            }
+        }
+        else
+        {
+            sb.AppendLine();
+            sb.AppendLine("No one is here.");
+        }
+
+        var items = whoIsHere.Where(x => x.Id.StartsWith("item:"));
+        if (items.Any())
+        {
+            sb.AppendLine();
+            sb.AppendLine("You see the following items:");
+            int i = 0;
+            foreach (var item in items)
+            {
+                var itm = session.GetGameElement<Item>(item.Id);
+                if (itm != null)
+                    sb.AppendLine($"{++i}. {itm.Name}");
+            }
+        }
+        else
+        {
+            sb.AppendLine();
+            sb.AppendLine("There are no items here.");
+        }
+
+        var exits = info?.Exits ?? Exits;
+        var visibleExits = exits.Where(e => !string.Equals(e.DefaultState, "hidden", StringComparison.OrdinalIgnoreCase));
+        if (visibleExits.Any())
+        {
+            sb.AppendLine();
+            sb.AppendLine("You can see these exits:");
+            int i = 0;
+            foreach (var exit in visibleExits)
+            {
+                var state = exit.DefaultState ?? "open";
+                var status = string.Equals(state, "locked", StringComparison.OrdinalIgnoreCase)
+                    ? " (locked)"
+                    : $" ({state})";
+                sb.AppendLine($"{++i}. {exit.Name} ({exit.TargetId}){status}");
+            }
+        }
+        else
+        {
+            sb.AppendLine();
+            sb.AppendLine("There are no exits from here.");
+        }
+
+        return sb.ToString();
+    }
 }


### PR DESCRIPTION
## Summary
- move `LookScene` logic to `Scene.ToDescription`
- adapt handlers to call `Scene.ToDescription`
- describe exits with state and hide hidden exits

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687efb587f4c8328a6047f28f3bae6a9